### PR TITLE
CSS Modules support

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -4,6 +4,7 @@ Copyright (c) 2014 Dan Abramov
 Copyright (c) 2015 Giampaolo Bellavite
 Copyright (c) 2015 Erik Rasmussen
 Copyright (c) 2015 Quangbuu Le
+Copyright (c) 2015 Tobias Koppers
 Copyright (c) 2015 Ronny Haryanto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ working app, showing how it is intended to work in real life.
     and source maps in development
 - ✓ [React] with JSX support
 - ✓ [react-router]
-- ✓ Server side rendering (~~isomorphic~~ [universal]) with [Express]
 - ✓ [Sass] with [autoprefixer]
 - ✓ Testing: [Karma], [Mocha], [Chai]
+- ✓ [CSS Modules]
 - images and fonts as component dependencies
-- [CSS Modules]
 - [redux] hot-reloadable atomic Flux with [Immutable]
+- Server side rendering (~~isomorphic~~ [universal]) with [Express]
 
 [Babel]: https://babeljs.io
 [eslint]: http://eslint.org

--- a/index.js
+++ b/index.js
@@ -6,4 +6,5 @@ require("babel/register")({
   sourceMaps: true
 });
 
+console.log("index.js");
 require("./src/server");

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "react": "^0.13.3",
     "react-document-title": "^1.0.2",
     "react-router": "^1.0.0-beta3",
-    "redux": "^1.0.0-alpha",
     "serialize-javascript": "^1.0.0",
     "serve-favicon": "^2.3.0",
     "webpack": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "start": "NODE_ENV=production node index",
     "postinstall": "npm run build",
     "test": "karma start config/karma.conf.js",
-
     "dev": "NODE_ENV=development nodemon index",
+    "builddev": "webpack --stats --progress --config ./webpack/dev.config.js",
     "build": "webpack --stats --progress --config ./webpack/prod.config.js",
     "lint": "eslint src"
   },
@@ -43,6 +43,7 @@
     "csurf": "^1.8.3",
     "express": "^4.13.0",
     "isomorphic-fetch": "^2.1.0",
+    "json-loader": "^0.5.2",
     "locale": "0.0.20",
     "morgan": "^1.6.0",
     "node-fetch": "^1.3.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <meta charSet="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+    <title>Loading...</title>
+    <!-- <link href="http://localhost:3001/assets/main.css" media="screen, projection" rel="stylesheet" type="text/css" /> -->
+  </head>
+  <body>
+    <div id="app">Loading...</div>
+    <script src="http://localhost:3001/webpack-dev-server.js"></script>
+    <script src="http://localhost:3001/assets/main.js"></script>
+  </body>
+</html>

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,7 +1,11 @@
+console.log("client");
+
 import React from "react";
 import { history } from "react-router/lib/BrowserHistory";
 import Router from "react-router";
 import routes from "../routes";
 
-console.log("client");
-React.render(<Router history={history} children={routes}/>, document.getElementById("app"));
+React.render(
+  <Router history={history} children={routes}/>,
+  document.getElementById("app")
+);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
-import Hello from "../Hello/Hello";
 import DocumentTitle from "react-document-title";
+import Hello from "../Hello/Hello";
 
 class App extends React.Component {
   static propTypes = {

--- a/src/components/Hello/Hello.js
+++ b/src/components/Hello/Hello.js
@@ -1,11 +1,6 @@
 import React, { PropTypes } from "react";
 
-// import styles from "./Hello.sass";
-if (process.env.BROWSER) {
-  var styles = require("./Hello.sass");
-} else {
-  var styles = {};
-}
+import styles from "./Hello.sass";
 
 class Hello extends React.Component {
   static propTypes = {

--- a/src/components/Hello/Hello.js
+++ b/src/components/Hello/Hello.js
@@ -1,8 +1,10 @@
 import React, { PropTypes } from "react";
-import DocumentTitle from "react-document-title";
 
+// import styles from "./Hello.sass";
 if (process.env.BROWSER) {
-  require("./Hello.sass");
+  var styles = require("./Hello.sass");
+} else {
+  var styles = {};
 }
 
 class Hello extends React.Component {
@@ -14,14 +16,12 @@ class Hello extends React.Component {
   };
 
   render() {
-    const text = `Hello, ${this.props.name}!`;
-
     return (
-      <DocumentTitle title={text}>
-        <div className="Hello">
-          <p>{text}</p>
-        </div>
-      </DocumentTitle>
+      <p className={styles.hello}>
+        <span className={styles.greeting}>Hello,</span>
+        <span className={styles.name}>{this.props.name}</span>
+        <span className={styles.exclamation}>!</span>
+      </p>
     );
   }
 }

--- a/src/components/Hello/Hello.sass
+++ b/src/components/Hello/Hello.sass
@@ -1,2 +1,9 @@
-.Hello
+.hello
   color: red
+
+.greeting,
+.exclamation
+  color: green
+
+.name
+  color: blue

--- a/src/components/HtmlDocument/HtmlDocument.js
+++ b/src/components/HtmlDocument/HtmlDocument.js
@@ -3,6 +3,7 @@ import ga from "./ga";
 import config from "../../../config";
 
 const webpackStats = require("../../../webpack-stats.json");
+console.dir(webpackStats);
 
 if (process.env.NODE_ENV === "development") {
   // Do not cache webpack stats: the script file would change since

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -6,8 +6,6 @@ import cookieParser from "cookie-parser";
 import favicon from "serve-favicon";
 import morgan from "morgan";
 import csurf from "csurf";
-// import locale from "locale";
-// import config from "../config";
 import render from "./render";
 
 const server = express();
@@ -18,19 +16,10 @@ server.use(cookieParser());
 server.use(compression());
 server.use(favicon(path.resolve(__dirname, "../components/HtmlDocument/favicon.png")));
 
-/////////////////////////////////////////////////////////////////////
-// Set the default locale
-// locale.Locale.default = config.locales[0];
-
-// Set req.locale based on the browser settings
-// server.use(locale(config.locales));
-
-// Overwrite req.locale either from cookie or querystring
-// server.use(setLocale);
-
-/////////////////////////////////////////////////////////////////////
-
 server.use(csurf({ cookie: true }));
+
+/////////////////////////////////////////////////////////////////////
+
 
 // On production, use the public directory for static files
 // This directory is created by webpack on build time.

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -6,7 +6,9 @@ import cookieParser from "cookie-parser";
 import favicon from "serve-favicon";
 import morgan from "morgan";
 import csurf from "csurf";
-import render from "./render";
+import fs from "fs";
+
+console.log("server/index.js");
 
 const server = express();
 
@@ -36,7 +38,13 @@ if (server.get("env") === "development") {
 
 /////////////////////////////////////////////////////////////////////
 // Render the app server-side and send it as response
-server.use(render);
+// import render from "./render.generated.js";
+// server.use(render);
+
+server.get("/", (req, res, next) => { // eslint-disable-line no-unused-vars
+  res.set("Content-Type", "text/html");
+  res.send(fs.readFileSync(path.resolve(__dirname, "../../public/index.html")));
+});
 
 // Generic server errors (e.g. not caught by components)
 server.use((err, req, res, next) => {  // eslint-disable-line no-unused-vars

--- a/src/server/render.js
+++ b/src/server/render.js
@@ -21,7 +21,7 @@ function render(req, res, next) {
         .then((state) => {
           console.log("state", state);
           const markup = React.renderToString(
-            <Router {...initialState} />
+            <Router location={location} {...initialState} />
           );
 
           console.log("rendering html");

--- a/src/server/render.js
+++ b/src/server/render.js
@@ -24,6 +24,7 @@ function render(req, res, next) {
             <Router {...initialState} />
           );
 
+          console.log("rendering html");
           // The application component is rendered to static markup (like
           // renderToString but without the react specific attrs) and sent as
           // response.

--- a/src/server/render.js
+++ b/src/server/render.js
@@ -16,7 +16,7 @@ function render(req, res, next) {
   try {
     const location = new Location(req.path, req.query);
 
-    Router.run(routes, location, (error, initialState) => {
+    Router.run(routes, location, (error, initialState = {}) => {
       fetchComponentsData(initialState.components)
         .then((state) => {
           console.log("state", state);

--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -4,6 +4,8 @@ import WebpackDevServer from "webpack-dev-server";
 import webpack from "webpack";
 import config from "./dev.config";
 
+console.log("webpack/dev-server");
+
 const debug = require("debug")(process.env.APP_NAME || "mfe");
 
 const WEBPACK_HOST = process.env.HOST || "localhost";
@@ -20,6 +22,8 @@ const serverOptions = {
 const compiler = webpack(config);
 const webpackDevServer = new WebpackDevServer(compiler, serverOptions);
 
+
 webpackDevServer.listen(WEBPACK_PORT, WEBPACK_HOST, () => {
   debug("Webpack development server listening on %s:%s", WEBPACK_HOST, WEBPACK_PORT);
+  console.log("Webpack development server listening on http://%s:%s", WEBPACK_HOST, WEBPACK_PORT);
 });

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -5,4 +5,5 @@ require("babel/register")({
   sourceMaps: true
 });
 
+console.log("webpack/dev.config");
 module.exports = require("./dev");

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -8,7 +8,10 @@ const assetsPath = path.resolve(__dirname, "../public/assets");
 const WEBPACK_HOST = "localhost";
 const WEBPACK_PORT = parseInt(process.env.PORT, 10) + 1 || 3001;
 
-export default {
+console.log("webpack/dev");
+
+const config = {
+  name: "browser",
   devtool: "cheap-module-eval-source-map",
   entry: {
     "main": [
@@ -19,9 +22,9 @@ export default {
   },
   output: {
     path: assetsPath,
-    filename: "[name]-[hash].js",
-    chunkFilename: "[name]-[hash].js",
-    publicPath: "http://" + WEBPACK_HOST + ":" + WEBPACK_PORT + "/assets/"
+    filename: "[name].js",
+    chunkFilename: "[name].js",
+    publicPath: "http://" + WEBPACK_HOST + ":" + WEBPACK_PORT + "/assets/",
   },
   module: {
     loaders: [
@@ -32,13 +35,20 @@ export default {
           "babel?optional[]=runtime&stage=0&cacheDirectory"
         ]
       },
-      shared.loaders.sass,
-      shared.loaders.image
+      {
+        ...shared.loaders.sass,
+        loaders: [
+          "style",
+          ...shared.loaders.sass.loaders,
+        ]
+      },
+      shared.loaders.image,
+      shared.loaders.json,
     ]
   },
   progress: true,
   resolve: shared.resolve,
-  // externals: shared.externals,
+  externals: shared.externals,
   plugins: [
 
     // hot reload
@@ -74,3 +84,8 @@ export default {
 
   ]
 };
+
+// console.log("dev webpack config");
+// console.dir(config);
+
+export default config;

--- a/webpack/dev.js
+++ b/webpack/dev.js
@@ -32,18 +32,13 @@ export default {
           "babel?optional[]=runtime&stage=0&cacheDirectory"
         ]
       },
-      {
-        test: shared.loaders.sass.test,
-        loaders: [
-          "style",
-          ...shared.loaders.sass.loaders
-        ]
-      },
+      shared.loaders.sass,
       shared.loaders.image
     ]
   },
   progress: true,
   resolve: shared.resolve,
+  // externals: shared.externals,
   plugins: [
 
     // hot reload

--- a/webpack/prod.js
+++ b/webpack/prod.js
@@ -39,6 +39,7 @@ export default {
   },
   progress: true,
   resolve: shared.resolve,
+  externals: shared.externals,
   plugins: [
     new ExtractTextPlugin("[name]-[hash].css"),
     new webpack.IgnorePlugin(/\.\/dev/, /\/config$/),

--- a/webpack/prod.js
+++ b/webpack/prod.js
@@ -7,62 +7,109 @@ import shared from "./shared";
 
 const assetsPath = path.join(__dirname, "../public/assets");
 
-export default {
-  devtool: "source-map",
-  entry: {
-    "main": "./src/client/index.js"
-  },
-  output: {
-    path: assetsPath,
-    filename: "[name]-[chunkhash].js",
-    chunkFilename: "[name]-[chunkhash].js",
-    publicPath: "/assets/"
-  },
-  module: {
+const commonLoaders = [
+  {
+    ...shared.loaders.js,
     loaders: [
-      {
-        ...shared.loaders.js,
-        loaders: [
-          strip.loader("debug"),
-          ...shared.loaders.js.loaders
-        ]
-      },
-      {
-        test: shared.loaders.sass.test,
-        loader: ExtractTextPlugin.extract(
-          "style",
-          shared.loaders.sass.loaders.join("!")
-        )
-      },
-      shared.loaders.image,
-    ],
+      "react-hot",
+      "babel?optional[]=runtime&stage=0&cacheDirectory"
+    ]
   },
-  progress: true,
-  resolve: shared.resolve,
-  externals: shared.externals,
-  plugins: [
-    new ExtractTextPlugin("[name]-[hash].css"),
-    new webpack.IgnorePlugin(/\.\/dev/, /\/config$/),
-    new webpack.DefinePlugin({
-      "process.env": {
-        // Mainly used to require CSS files with webpack, which can happen only on browser
-        // Used as `if (process.env.BROWSER)...`
-        BROWSER: JSON.stringify(true),
-        // Useful to reduce the size of client-side libraries, e.g. react
-        NODE_ENV: JSON.stringify("production"),
-        __CLIENT__: true,
-        __SERVER__: false,
-      }
-    }),
+  shared.loaders.image,
+  shared.loaders.json,
+];
 
-    new webpack.optimize.DedupePlugin(),
-    new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false
-      }
-    }),
+export default [
+  {
+    devtool: "source-map",
+    entry: {
+      "main": "./src/client/index.js"
+    },
+    output: {
+      path: assetsPath,
+      filename: "[name]-[chunkhash].js",
+      chunkFilename: "[name]-[chunkhash].js",
+      publicPath: "/assets/",
+      libraryTarget: "umd",
+    },
+    module: {
+      loaders: [
+        {
+          ...shared.loaders.js,
+          loaders: [
+            strip.loader("debug"),
+            ...shared.loaders.js.loaders
+          ]
+        },
+        {
+          test: shared.loaders.sass.test,
+          loader: ExtractTextPlugin.extract(
+            "style",
+            shared.loaders.sass.loaders.join("!")
+          )
+        },
+        shared.loaders.image,
+      ],
+    },
+    progress: true,
+    resolve: shared.resolve,
+    externals: shared.externals,
+    plugins: [
+      new ExtractTextPlugin("[name]-[hash].css"),
+      new webpack.IgnorePlugin(/\.\/dev/, /\/config$/),
+      new webpack.DefinePlugin({
+        "process.env": {
+          // Mainly used to require CSS files with webpack, which can happen only on browser
+          // Used as `if (process.env.BROWSER)...`
+          BROWSER: JSON.stringify(true),
+          // Useful to reduce the size of client-side libraries, e.g. react
+          NODE_ENV: JSON.stringify("production"),
+          __CLIENT__: true,
+          __SERVER__: false,
+        }
+      }),
 
-    function() { this.plugin("done", writeStats); }
-  ]
-};
+      new webpack.optimize.DedupePlugin(),
+      new webpack.optimize.OccurenceOrderPlugin(),
+      new webpack.optimize.UglifyJsPlugin({
+        compress: {
+          warnings: false
+        }
+      }),
+
+      function() { this.plugin("done", writeStats); }
+    ]
+  },
+  {
+    name: "server-side rendering",
+    entry: "./src/server/render.js",
+    target: "node",
+    output: {
+      path: assetsPath,
+      filename: "../../src/server/render.generated.js",
+      publicPath: "http://" + WEBPACK_HOST + ":" + WEBPACK_PORT + "/assets/",
+      libraryTarget: "commonjs2",
+    },
+    externals: shared.externals,
+    module: {
+      loaders: [
+        ...commonLoaders,
+        {
+          ...shared.loaders.css,
+          loaders: [
+            "css/locals?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]",
+            "autoprefixer?browsers=last 2 version",
+          ]
+        },
+        {
+          ...shared.loaders.sass,
+          loaders: [
+            "css/locals?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]",
+            "autoprefixer?browsers=last 2 version",
+            "sass?indentedSyntax",
+          ]
+        }
+      ]
+    }
+  }
+];

--- a/webpack/shared.js
+++ b/webpack/shared.js
@@ -1,3 +1,15 @@
+import fs from "fs";
+
+const nodeModules =
+  fs.readdirSync("node_modules")
+    .filter(x => ([".bin"].indexOf(x) === -1))
+    .reduce((mods, mod) => {
+      mods[mod] = "commonjs " + mod;
+      return mods;
+    }, {});
+
+// console.log("nodeModules", nodeModules);
+
 export default {
   loaders: {
     js: {
@@ -10,7 +22,7 @@ export default {
     sass: {
       test: /\.sass$/,
       loaders: [
-        "css",
+        "css/locals?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]",
         "autoprefixer?browsers=last 2 version",
         "sass?indentedSyntax",
       ]
@@ -22,7 +34,19 @@ export default {
   },
 
   resolve: {
-    extensions: ["", ".js", ".sass", ".jpg", ".png", ".svg", ".gif"],
+    // Only allow ".js" to be appended automatically when resolving (e.g.
+    // `import foo from "./bar"` will find `./bar.js`), everything else must
+    // be specified with the full extension, e.g. `import styles from
+    // "./bar.sass"`
+    extensions: ["", ".js"],
+
+    // When resolving module paths (i.e. non-absolute and non-relative, e.g.
+    // `import foo from "blah/foo"`), webpack will look in these dirs and any
+    // parent dirs above it with the same names (e.g. `./blah`, `../blah`,
+    // `../../blah`, etc).
     modulesDirectories: ["src", "node_modules"],
-  }
+  },
+
+  // No need to include node_modules in the bundle.
+  // externals: nodeModules,
 };

--- a/webpack/shared.js
+++ b/webpack/shared.js
@@ -1,15 +1,3 @@
-import fs from "fs";
-
-const nodeModules =
-  fs.readdirSync("node_modules")
-    .filter(x => ([".bin"].indexOf(x) === -1))
-    .reduce((mods, mod) => {
-      mods[mod] = "commonjs " + mod;
-      return mods;
-    }, {});
-
-// console.log("nodeModules", nodeModules);
-
 export default {
   loaders: {
     js: {
@@ -22,7 +10,7 @@ export default {
     sass: {
       test: /\.sass$/,
       loaders: [
-        "css/locals?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]",
+        "css?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]",
         "autoprefixer?browsers=last 2 version",
         "sass?indentedSyntax",
       ]
@@ -31,6 +19,10 @@ export default {
       test: /\.(jpe?g|png|gif|svg|ico)$/,
       loaders: ["file"]
     },
+    json: {
+      test: /\.json$/,
+      loaders: ["json"]
+    }
   },
 
   resolve: {
@@ -46,7 +38,4 @@ export default {
     // `../../blah`, etc).
     modulesDirectories: ["src", "node_modules"],
   },
-
-  // No need to include node_modules in the bundle.
-  // externals: nodeModules,
 };


### PR DESCRIPTION
https://github.com/css-modules/css-modules

I had to disable server side rendering, though, because we're doing the server side rendering in node, and import/require-ing non-js files won't work. The [recommended way](https://github.com/webpack/css-loader/issues/59) of doing this is to let Webpack build everything first (using a separate prerender-only Webpack config) and then use the webpack-built files to do server-side rendering with node. This requires a lot of rework on the Webpack stuff so I'm pushing this to a bit later.